### PR TITLE
Add Cuju and qCUDA repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@
 37|[@Thomas-Tsai](https://github.com/Thomas-Tsai)/[**partclone**](https://github.com/Thomas-Tsai/partclone) |  Partclone provides utilities to backup a partition smartly and it is designed for higher compatibility of the file system by using existing library. | [:arrow_upper_right:](http://partclone.org)
 31|[@buganini](https://github.com/buganini)/[**bsdconv**](https://github.com/buganini/bsdconv) |BSD licensed charset/encoding converter library with more functionalities than libiconv|
 29|[@jserv](https://github.com/jserv)/[**codezero**](https://github.com/jserv/codezero) |Codezero Microkernel|
+24|[@Cuju-ft](https://github.com/Cuju-ft)/[**Cuju**](https://github.com/Cuju-ft/Cuju) |An Open Source Project for Virtualization-Based Fault Tolerance|[:arrow_upper_right:](https://cuju-ft.github.io/cuju-web/home.html)
 23|[@HawxChen](https://github.com/HawxChen)/[**MIT-6.828-Adventure**](https://github.com/HawxChen/MIT-6.828-Adventure) |I love OS. I implement it.|[:arrow_upper_right:](http://hawxchen.blogspot.com)
 17|[@browny](https://github.com/browny)/[**hand-tracking**](https://github.com/browny/hand-tracking) |A simple multiple hands tracking implementation based on OpenCV library|
 17|[@scottt](https://github.com/scottt)/[**openssl-android**](https://github.com/scottt/openssl-android) |Official Android OpenSSL patched to build as an external project with the Android NDK|

--- a/README.md
+++ b/README.md
@@ -393,6 +393,7 @@
 4|[@olvaffe](https://github.com/olvaffe)/[**mesa**](https://github.com/olvaffe/mesa) |http://cgit.freedesktop.org/mesa/mesa/|
 4|[@buganini](https://github.com/buganini)/[**chiconv**](https://github.com/buganini/chiconv) |Auto chinese encoding converter|
 4|[@tjwei](https://github.com/tjwei)/[**KindleChewing**](https://github.com/tjwei/KindleChewing) |Chewing Chinese Input Method for Kindle DX|
+3|[@coldfunction](https://github.com/coldfunction)/[**qCUDA**](https://github.com/coldfunction/qCUDA) |A first opensource project for GPGPU virtualization in Taiwan|
 3|[@cleaton](https://github.com/cleaton)/[**android_kernel_samsung_smdk4210**](https://github.com/cleaton/android_kernel_samsung_smdk4210) |Kernel for Samsung SMDK4210 Boards|
 3|[@kanru](https://github.com/kanru)/[**chinese-type-practice**](https://github.com/kanru/chinese-type-practice) ||
 3|[@Hom-Wang](https://github.com/Hom-Wang)/[**SerialDebugAssistant**](https://github.com/Hom-Wang/SerialDebugAssistant) |QT Serial Debug Assistant|


### PR DESCRIPTION
Two repositories I would like to introduce them to developers
Cuju: An opensource project for Virtualization-Based Fault Tolerance
https://cuju-ft.github.io/cuju-web/home.html

qCUDA: An opensource project for GPGPU virtualization
https://github.com/coldfunction/qCUDA
